### PR TITLE
Fixed broken loop in edge cases

### DIFF
--- a/sm-notebook/1_DeployEndpoint.ipynb
+++ b/sm-notebook/1_DeployEndpoint.ipynb
@@ -97,6 +97,7 @@
     "for bucket in response['Buckets']:\n",
     "    if 'yolov8' in bucket[\"Name\"]:\n",
     "        bucket = 's3://' + bucket[\"Name\"]\n",
+    "        break\n",
     "\n",
     "print(f'Bucket: {bucket}')\n",
     "sess = sagemaker.Session(default_bucket=bucket.split('s3://')[-1])\n",


### PR DESCRIPTION
*Issue #, if available:*
If there are other buckets after the one that triggers the if* statement in the for-loop, it bugs out because the bucket value gets replaced.

*Description of changes:*
Added a *break to preven behaviour.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
