### PR TITLE
fix: upgrade aws-cdk-lib to 2.28.0

### DIFF
--- a/yolov8-pytorch-cdk/requirements.txt
+++ b/yolov8-pytorch-cdk/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.22.0
+aws-cdk-lib==2.28.0
 constructs<=11.0.0
 jsonpickle~=2.2.0
 boto3~=1.24.1


### PR DESCRIPTION
*Resolves #9 * 

*Description of changes:*  Upgraded `aws-cdk-lib` version to `2.28.0`.

Issue was being caused by `aws-cdk-lib==2.22.0`, which uses an unsupported version of node (nodejs12.x) for creating and updating Lambda functions for creating custom AWS resources.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
