### PR TITLE
Updating CDK version due unsupported Node.js runtime

### DIFF
--- a/yolov8-pytorch-cdk/requirements.txt
+++ b/yolov8-pytorch-cdk/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.22.0
+aws-cdk-lib==2.139.1
 constructs<=11.0.0
 jsonpickle~=2.2.0
 boto3~=1.24.1


### PR DESCRIPTION
*Issue #, if available:*
When running `cdk deploy`, I received the following error:
`The runtime parameter of nodejs12.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs18.x) while creating or updating functions.`

After doing some research, I determined that this was being caused by the older version of CDK. Upgrading the version allowed me to successfully deploy the stack.

*Description of changes:*
- Updating the version of CDK from 2.22.0 to 2.139.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
